### PR TITLE
backend for custom budget allocation

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -28,6 +28,35 @@ app.use(session({
   saveUninitialized: false,
   cookie: { secure: false, httpOnly: true, maxAge: 1000 * 60 * 60 } // 1-hour session
 }))
+app.get("/trips/allocation-presets", (req, res) => {
+  const presets = {
+    balanced: {
+      Food: 30,
+      Transport: 10,
+      Lodging: 25,
+      Activities: 20,
+      Shopping: 10,
+      Other: 5,
+    },
+    luxury: {
+      Food: 25,
+      Transport: 20,
+      Lodging: 35,
+      Activities: 15,
+      Shopping: 3,
+      Other: 2,
+    },
+    budget: {
+      Food: 40,
+      Transport: 15,
+      Lodging: 30,
+      Activities: 10,
+      Shopping: 3,
+      Other: 2,
+    }
+  };
+  res.json({presets});
+});
 app.use(authRoutes)
 app.use('/trips', triproutes)
 app.use('/trips', eventroutes)

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -87,8 +87,10 @@ model Note{
 model Budget{
   id Int @id @default(autoincrement())
   amount Decimal @db.Money
+  allocations Json?
   tripId Int
   trip   Trip @relation(fields: [tripId], references: [id])
   userId Int
   user   User  @relation(fields: [userId], references: [id], onDelete: Cascade) // Defines the relationship
+  @@unique([tripId, userId])
 }

--- a/backend/routes/budget.js
+++ b/backend/routes/budget.js
@@ -10,6 +10,16 @@ const isAuthenticated = (req, res, next) => {
   next();
 };
 
+const default_allocations={
+  Food: 30,
+  Transport: 10,
+  Lodging: 25,
+  Activities: 20,
+  Shopping: 10,
+  Other: 5,
+}
+
+
 // get budget for a trip
 router.get("/:tripId/budget", async (req, res) => {
   try {
@@ -62,6 +72,139 @@ router.put("/:tripId/budget", isAuthenticated, async (req, res) => {
     res.status(500).json({ error: "Something went wrong while updating budget." });
   }
 });
+router.get("/:tripId/budget-allocations", async (req, res) => {
+  try {
+    const tripId = parseInt(req.params.tripId);
+    
+    const budget = await prisma.budget.findFirst({
+      where: {
+        tripId: tripId,
+      },
+      orderBy: { id: 'desc' }
+    });
+    
+    if (budget && budget.allocations) {
+      // Return saved allocations
+      res.json({ 
+        allocations: budget.allocations,
+        isDefault: false 
+      });
+    } else {
+      // Return default allocations
+      res.json({ 
+        allocations: default_allocations,
+        isDefault: true 
+      });
+    }
+  } catch (error) {
+    console.error("Error fetching budget allocations:", error);
+    res.status(500).json({ error: "Something went wrong while fetching budget allocations." });
+  }
+});
 
+// create/update budget allocations
+router.put("/:tripId/budget-allocations", isAuthenticated, async (req, res) => {
+  const { allocations } = req.body;
+  
+  if (!allocations || typeof allocations !== 'object') {
+    return res.status(400).json({ error: "Budget allocations are required" });
+  }
+  
+  // Validate that allocations sum to 100
+  const total = Object.values(allocations).reduce((sum, val) => sum + (parseFloat(val) || 0), 0);
+  if (Math.abs(total - 100) > 0) {
+    return res.status(400).json({ error: "Budget allocations must sum to 100%" });
+  }
+  
+  try {
+    const tripId = parseInt(req.params.tripId);
+    
+    // Verify trip ownership
+    const trip = await prisma.trip.findUnique({
+      where: { id: tripId }
+    });
+  
+    if (!trip || trip.userId !== req.session.userId) {
+      return res.status(403).json({ error: "Access denied" });
+    }
+    
+    // Find existing budget for this trip
+    const existingBudget = await prisma.budget.findFirst({
+      where: {
+        tripId: tripId,
+      },
+      orderBy: { id: 'desc' }
+    });
+    
+    let updatedBudget;
+    
+    if (existingBudget) {
+      // Update existing budget with new allocations
+      updatedBudget = await prisma.budget.update({
+        where: { id: existingBudget.id },
+        data: { allocations: allocations }
+      });
+    } else {
+      // Create new budget with allocations if none exists
+      updatedBudget = await prisma.budget.create({
+        data: {
+          amount: 0, // Default amount
+          allocations: allocations,
+          tripId: tripId,
+          userId: req.session.userId
+        }
+      });
+    }
+  
+    res.json({ 
+      allocations: updatedBudget.allocations,
+      isDefault: false 
+    });
+  } catch (error) {
+    console.error("Error updating budget allocations:", error);
+    res.status(500).json({ error: "Something went wrong while updating budget allocations." });
+  }
+});
+
+// reset budget allocations to default
+router.delete("/:tripId/budget-allocations", isAuthenticated, async (req, res) => {
+  try {
+    const tripId = parseInt(req.params.tripId);
+    
+    // Verify trip ownership
+    const trip = await prisma.trip.findUnique({
+      where: { id: tripId }
+    });
+  
+    if (!trip || trip.userId !== req.session.userId) {
+      return res.status(403).json({ error: "Access denied" });
+    }
+    
+    // Find existing budget
+    const existingBudget = await prisma.budget.findFirst({
+      where: {
+        tripId: tripId,
+      },
+      orderBy: { id: 'desc' }
+    });
+    
+    if (existingBudget) {
+      // Reset allocations to null or default
+      await prisma.budget.update({
+        where: { id: existingBudget.id },
+        data: { allocations: null }
+      });
+    }
+  
+    res.json({ 
+      allocations: default_allocations,
+      isDefault: true,
+      message: "Budget allocations reset to default"
+    });
+  } catch (error) {
+    console.error("Error resetting budget allocations:", error);
+    res.status(500).json({ error: "Something went wrong while resetting budget allocations." });
+  }
+}); 
 module.exports = router;
 


### PR DESCRIPTION
## Description
The feature allows users to allocate specific percentages of their budget to various categories according to their preferences. A new column for allocations has been added to the budget schema. Additionally, there are predefined allocation options available for users to select. Users have the flexibility to modify the allocation percentages or revert them to the default settings.

## Milestones
Technical Challenge 2: Expense Suggestions

## Resources
[https://www.prisma.io/docs/orm/reference/prisma-schema-reference#unique-1](url)

## Test Plan
The functionality has been tested through the front-end. The tests include modifying percentage allocations across categories, resetting them to default values, selecting preset options, and verifying the persistence of these changes across sessions.
