### PR TITLE
History preset

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -28,7 +28,8 @@ app.use(session({
   saveUninitialized: false,
   cookie: { secure: false, httpOnly: true, maxAge: 1000 * 60 * 60 } // 1-hour session
 }))
-app.get("/trips/allocation-presets", (req, res) => {
+app.get("/trips/allocation-presets", async (req, res) => {
+  const tripId = req.query.tripId ? parseInt(req.query.tripId) : null;
   const presets = {
     balanced: {
       Food: 30,
@@ -55,6 +56,93 @@ app.get("/trips/allocation-presets", (req, res) => {
       Other: 2,
     }
   };
+
+  // Only add the historical preset if the user is logged in
+  if (req.session.userId) {
+    try {
+      const { PrismaClient } = require('@prisma/client');
+      const prisma = new PrismaClient();
+      // If tripId is provided, get the current trip's start date
+      let currentTripStartDate = null;
+      if (tripId) {
+        const currentTrip = await prisma.trip.findUnique({
+          where: { id: tripId }
+        });
+        if (currentTrip) {
+          currentTripStartDate = currentTrip.start_date;
+        }
+      }
+      // Get trips for the current user
+      const userTrips = await prisma.trip.findMany({
+        where: {
+          userId: req.session.userId,
+          // Only include trips that end before the current trip starts 
+          ...(currentTripStartDate ? {
+            end_date: {
+              lt: currentTripStartDate
+            }
+          } : {})
+        },
+        include: {
+          expenses: true,
+          budget: true
+        },
+        orderBy: { start_date: 'desc' }
+      });
+      // Filter trips that have expenses
+      const tripsWithExpenses = userTrips.filter(trip => trip.expenses.length > 0);
+      // If there are trips with expenses, calculate the spending pattern
+      if (tripsWithExpenses.length > 0) {
+        // Initialize categories and spending totals
+        const categories = ['Food', 'Transport', 'Lodging', 'Activities', 'Shopping', 'Other'];
+        const categorySpending = {};
+        let totalSpending = 0;
+        categories.forEach(category => categorySpending[category] = 0);
+        // Sum up actual spending by category for all trips
+        tripsWithExpenses.forEach(trip => {
+          trip.expenses.forEach(expense => {
+            const category = expense.category;
+            const amount = parseFloat(expense.amount);
+            if (categories.includes(category)) {
+              categorySpending[category] += amount;
+              totalSpending += amount;
+            } else {
+              // If category doesn't match predefined categories, add to Other
+              categorySpending['Other'] += amount;
+              totalSpending += amount;
+            }
+          });
+        });
+        // Calculate percentages based on actual spending
+        const historical = {};
+        if (totalSpending > 0) {
+          categories.forEach(category => {
+            const percentage = (categorySpending[category] / totalSpending) * 100;
+            historical[category] = Math.round(percentage);
+          });
+          // Ensure allocations sum to 100%
+          const total = Object.values(historical).reduce((acc, val) => acc + val, 0);
+          if (total !== 100) {
+            const adjustment = 100 - total;
+            // Distribute the adjustment across categories
+            const adjustmentPerCategory = Math.floor(adjustment / categories.length);
+            categories.forEach(category => {
+              historical[category] += adjustmentPerCategory;
+            });
+            // Add any remaining adjustment to the first category
+            const remaining = adjustment - (adjustmentPerCategory * categories.length);
+            historical[categories[0]] += remaining;
+          }
+          // Add historical preset
+          presets.historical = historical;
+        }
+      }
+    } catch (error) {
+      console.error("Error calculating historical budget allocations:", error);
+      // Don't add the historical preset if there's an error
+    }
+  }
+
   res.json({presets});
 });
 app.use(authRoutes)

--- a/frontend/src/components/BudgetSettings.jsx
+++ b/frontend/src/components/BudgetSettings.jsx
@@ -9,7 +9,7 @@ const BudgetSettings = ({
   isOpen,
   onClose,
   loading=false,
-
+  tripId,
 }) => {
   const [tempAllocations, setTempAllocations] = useState(allocations);
   const [showPresets, setShowPresets] = useState(false);
@@ -23,7 +23,10 @@ const BudgetSettings = ({
   const loadPresets = async () => {
     try {
       setLoadingPresets(true);
-      const response = await fetch(`${APP_URL}/trips/allocation-presets`, {
+      const url = tripId
+        ? `${APP_URL}/trips/allocation-presets?tripId=${tripId}`
+        : `${APP_URL}/trips/allocation-presets`;
+      const response = await fetch(url, {
         credentials: 'include',
         headers:{
             'Content-Type': 'application/json'

--- a/frontend/src/components/BudgetSuggestions.jsx
+++ b/frontend/src/components/BudgetSuggestions.jsx
@@ -143,6 +143,7 @@ const BudgetSuggestions = ({ expenses, budget, categories, tripId, tripStart, tr
         isOpen={showSettings}
         onClose={() => setShowSettings(false)}
         loading={loading}
+        tripId={tripId}
       />
       {suggestions.length > 0 && (
         <div className="budget-suggestions-section">


### PR DESCRIPTION
## Description
This endpoint calculates a historical budget allocation preset based on the user's spending patterns from previous trips. It filters for all trips that ended before the current trip's start date, ensuring only relevant past trips with recorded expenses are considered. The function then sums the spending across different categories and computes the percentage share of each category relative to the total spending. Finally, it ensures that the sum of all category percentages equals 100%.

## Milestones
Technical Challenge 2: Expense Suggestions

## Test Plan
I tested this by creating multiple trips with expenses and calculating the expense  allocation. I then checked if this matched up with the preset's allocations. I tested to make sure the preset only considers past trips. 
